### PR TITLE
v0.3: more libc improvements

### DIFF
--- a/.github/workflows/dev-pytest.yml
+++ b/.github/workflows/dev-pytest.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Grab libc-database
       run: |
         git clone --depth 1 https://github.com/niklasb/libc-database
+        apt-get install -y binutils file
     - name: Test with pytest
       run: |
         chmod +x examples/*.c # Might be rw-

--- a/.github/workflows/dev-pytest.yml
+++ b/.github/workflows/dev-pytest.yml
@@ -40,4 +40,4 @@ jobs:
       run: |
         chmod +x examples/*.c # Might be rw-
         export TERM=linux export TERMINFO=/etc/terminfo
-        pytest || pytest    # Bad idea
+        pytest || pytest || pytest    # Bad idea

--- a/.github/workflows/dev-pytest.yml
+++ b/.github/workflows/dev-pytest.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Grab libc-database
       run: |
         git clone --depth 1 https://github.com/niklasb/libc-database
-        apt-get install -y binutils file
+        sudo apt-get install -y binutils file
     - name: Test with pytest
       run: |
         chmod +x examples/*.c # Might be rw-

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Grab libc-database
       run: |
         git clone --depth 1 https://github.com/niklasb/libc-database
+        apt-get install -y binutils file
     - name: Test with pytest
       run: |
         chmod +x examples/*.c # Might be rw-

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Grab libc-database
       run: |
         git clone --depth 1 https://github.com/niklasb/libc-database
-        apt-get install -y binutils file
+        sudo apt-get install -y binutils file
     - name: Test with pytest
       run: |
         chmod +x examples/*.c # Might be rw-

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ More features exist, but this is already too long.
 pwnscripts provides the `fsb` module, which can be split further into:
   * `.find_offset`: helper functions to bruteforce wanted printf offsets.
 
-    If you've ever found yourself spamming `%n$llx` into a terminal: this module will automate away all that. Take a look at the [example code](user_tests_and_examples.py) to see how.
+    If you've ever found yourself spamming `%n$llx` into a terminal: this module will automate away all that. Take a look at the [example code](test_automated.py) to see how.
 
     This already partially exists as a feature in pwntools (see `pwnlib.fmtstr.FmtStr`), but pwnscripts expands functionality by having bruteforcers for other important printf offsets, including
     1. `canary`s, for defeating stack protectors,
@@ -129,7 +129,7 @@ Pwnscripts also comes with a few minor extensions and functions:
 Proper examples for `pwnscripts` are available in `examples/` and `user_tests_and_examples.py`.
 ## I tried using it; it doesn't work!
 
-File in an [issue](https://github.com/152334H/pwnscripts/issues), if you can. With a single-digit userbase , it's hard to guess what might go wrong, but potentially:
+File in an [issue](https://github.com/152334H/pwnscripts/issues), if you can. With a single-digit userbase, it's hard to guess what might go wrong, but potentially:
  * pwnscripts is broken
  * Python is outdated (try python3.8+)
  * libc-database is not properly installed/initalised (did you run ./get?)
@@ -140,6 +140,12 @@ File in an [issue](https://github.com/152334H/pwnscripts/issues), if you can. Wi
  * Other unknown reasons. Try making a pull-request if you're interested.
 
 ## Updates
+
+Upcoming:
+ * `context.libc.run_with()` to run an ELF with a specific libc version.
+ * `context.libc.dir()` to get the `/path/to/libc-database/libs/libc.id/`
+ * `ELF` now has an `.ldd_libs()` method to get a list of libs used by a binary.
+ * `rop.system_call()` can now search for `'syscall; ret'` instructions.
 
 **v0.2.1** - Hotfix: `libc.select_gadget()` will return with the correct `libc.address` adjusted value
 

--- a/examples/fastbin_dup.c
+++ b/examples/fastbin_dup.c
@@ -1,0 +1,8 @@
+//usr/bin/gcc "$0" -o f.out; exit
+#include <stdio.h>
+#include <stdlib.h>
+int main() {
+	int *a = malloc(8), *b = malloc(8), *c = malloc(8);
+	free(a); free(b); free(a);
+	malloc(8); malloc(8); malloc(8);
+}

--- a/pwnscripts/__init__.py
+++ b/pwnscripts/__init__.py
@@ -1,6 +1,7 @@
 '''A simple QoL module to make doing repetitive pwn easier'''
 from pwn import *
 from pwnscripts.context import context
+from pwnscripts.elf import *
 from pwnscripts.string_checks import *
 from pwnscripts.libcdb_query import *
 from pwnscripts.uncommon import *

--- a/pwnscripts/elf.py
+++ b/pwnscripts/elf.py
@@ -1,6 +1,8 @@
 from os import path
 from subprocess import check_output
 import pwnlib
+
+from pwnscripts.context import context
 class ELF(pwnlib.elf.elf.ELF):
 	def ldd_libs(self):
 		'''For whatever reason, ELF.libs appears to be ineffectual.
@@ -8,3 +10,8 @@ class ELF(pwnlib.elf.elf.ELF):
 		ldd = check_output(['ldd', self.path]).decode()
 		libpaths = pwnlib.util.misc.parse_ldd_output(ldd).keys()
 		return list(map(path.basename, libpaths))
+
+	def process(self, argv=[], *a, **kw):
+		if context.libc is None:
+			return super().process(argv, *a, **kw)
+		return context.libc.run_with(self, argv, *a, **kw)

--- a/pwnscripts/elf.py
+++ b/pwnscripts/elf.py
@@ -1,0 +1,10 @@
+from os import path
+from subprocess import check_output
+import pwnlib
+class ELF(pwnlib.elf.elf.ELF):
+	def ldd_libs(self):
+		'''For whatever reason, ELF.libs appears to be ineffectual.
+		'''
+		ldd = check_output(['ldd', self.path]).decode()
+		libpaths = pwnlib.util.misc.parse_ldd_output(ldd).keys()
+		return list(map(path.basename, libpaths))

--- a/pwnscripts/elf.py
+++ b/pwnscripts/elf.py
@@ -4,14 +4,23 @@ import pwnlib
 
 from pwnscripts.context import context
 class ELF(pwnlib.elf.elf.ELF):
-	def ldd_libs(self):
-		'''For whatever reason, ELF.libs appears to be ineffectual.
+	def ldd_libs(self) -> list:
+		'''ELF.libs fails on wsl. This function is here for that purpose.
+		Returns: list of library basenames detected by ldd.
 		'''
 		ldd = check_output(['ldd', self.path]).decode()
 		libpaths = pwnlib.util.misc.parse_ldd_output(ldd).keys()
 		return list(map(path.basename, libpaths))
 
-	def process(self, argv=[], *a, **kw):
+	def process(self, argv=[], *a, **kw) -> pwnlib.tubes.process.process:
+		'''pwnscripts overridden .process() method
+		If `context.libc` is set, process() will run
+			context.libc.run_with(self, argv, *a, **kw)
+		Otherwise, the original pwntools' ELF.process() is called.
+
+		Returns:
+			pwnlib.tubes.process.process() object
+		'''
 		if context.libc is None:
 			return super().process(argv, *a, **kw)
 		return context.libc.run_with(self, argv, *a, **kw)

--- a/pwnscripts/libcdb_query.py
+++ b/pwnscripts/libcdb_query.py
@@ -1,5 +1,5 @@
 '''Reinventing the wheel for LibcSearcher
-See examples/, or try starting with libc_db().
+See examples/, or try starting with libc().
 '''
 from re import search
 from glob import glob
@@ -391,7 +391,7 @@ class libc(ELF):
         assert 0 <= option < len(self.one_gadget)
         return self.one_gadget[option] + self.address
 
-    def dir(self):
+    def dir(self) -> str:
         '''Get the '/path/to/libc-database/libs/self.id' for this libc
         Will raise ValueError if the libc is a locally imported libc
         '''
@@ -405,7 +405,7 @@ class libc(ELF):
             self.db.download(self.id)   # download it
         return lib_dir
 
-    def run_with(self, binary: ELF, argv=[], *a, **kw):
+    def run_with(self, binary: ELF, argv=[], *a, **kw) -> process:
         '''Run a `binary` with arguments `argv` using this libc's associated libs/ path.
 
         Arguments:

--- a/pwnscripts/rop.py
+++ b/pwnscripts/rop.py
@@ -1,4 +1,6 @@
 '''An extension of pwnlib.rop.rop.ROP.'''
+from pkg_resources import parse_version
+from pwnlib import __version__ as PWNLIB_VER
 from pwnlib import rop
 from pwnlib.rop.call import Call
 from pwnlib.util.packing import flat
@@ -15,7 +17,7 @@ class ROP(rop.rop.ROP):
         '''Dump the ROP chain in an easy-to-read manner
         Optional `base` argument to change the ROP base'''
         return self.build(base=base).dump()
-    def system_call(self, num: int, args: list):
+    def system_call(self, num: int, args: list, ret: bool=False):
         '''Making system calls without the massive overhead of SIGROP
         >>> context.arch = 'amd64'
         >>> r = ROP('./binary')
@@ -30,13 +32,31 @@ class ROP(rop.rop.ROP):
         0x0030:             0x40 [arg0] rdi = AppendedArgument(['/bin/sh'], 0x0)
         0x0038:         0x4022b4 syscall
         0x0040:   b'/bin/sh\x00'
+
+        Arguments:
+            `num`: the syscall number
+            `args`: arguments to the syscall
+            `ret`: Specifically use a 'syscall; ret' gadget for syscalls (instead of 'syscall')
+                `ret` WILL NOT WORK unless you have the dev verison of pwntools installed.
+        
+        Returns:
+            Nothing. Will raise errors if things go wrong.
         '''
         if context.arch != 'amd64':
             raise NotImplementedError("syscall_call() is only implemented for amd64 right now")
-        if self.syscall is None:
+        # get the syscall gadget
+        if ret:
+            if parse_version(PWNLIB_VER) < parse_version('4.4.0dev0'):
+                raise NotImplementedError('"syscall; ret" gadgets are only available on the '
+                'latest version of pwntools.')
+            syscall = self.find_gadget(['syscall', 'ret'])
+        else:
+            syscall = self.syscall
+        if syscall is None:
             raise AttributeError("ROP unable to find syscall gadget")
+        # write the rop chain
         self.pop({'rax': num})
-        self.raw(Call('syscall', self.syscall.address, args))
+        self.raw(Call('syscall', syscall.address, args))
     def pop(self, registers: dict):
         '''convinence function to edit a few registers
         >>> rop = ROP("./binary")

--- a/test_automated.py
+++ b/test_automated.py
@@ -122,8 +122,10 @@ class BinTests(ut.TestCase):
         '''Simple test to check that local-* libcs will crash for self.dir()
         '''
         print()
+        LOCAL_ID = 'local-18292bd12d37bfaf58e8dded9db7f1f5da1192cb'
         context.libc_database = 'libc-database'
-        context.libc_database.add('examples/libc.so.6')
+        if not path.isfile(path.join(context.libc_database.db_dir, 'db', LOCAL_ID+'.so')):
+            context.libc_database.add('examples/libc.so.6')
         context.libc = 'local-18292bd12d37bfaf58e8dded9db7f1f5da1192cb'
         self.assertRaises(ValueError, context.libc.dir)
 

--- a/test_automated.py
+++ b/test_automated.py
@@ -121,13 +121,18 @@ class BinTests(ut.TestCase):
     # TODO: tests for ROP
     def test_E_libc(self):
         '''Simple test to check that local-* libcs will crash for self.dir()
+
+        It's important that we *don't* run `context.libc = 'examples/libc.so.6' for this test.
+        Although it'll work fine on GitHub Actions, an actual user (like you) may have
+        a fully ./get'd libc-database, and 'examples/libc.so.6' will be identified as a non-local
+        lib if the binary filepath is passed to context.libc.
         '''
         print()
         LOCAL_ID = 'local-18292bd12d37bfaf58e8dded9db7f1f5da1192cb'
         context.libc_database = 'libc-database'
         if not path.isfile(path.join(context.libc_database.db_dir, 'db', LOCAL_ID+'.so')):
             context.libc_database.add('examples/libc.so.6')
-        context.libc = 'local-18292bd12d37bfaf58e8dded9db7f1f5da1192cb'
+        context.libc = LOCAL_ID
         self.assertRaises(ValueError, context.libc.dir)
 
         for f in glob.glob(context.libc.libpath+'*'):   # not that smart

--- a/test_automated.py
+++ b/test_automated.py
@@ -42,6 +42,7 @@ class BinTests(ut.TestCase):
         lib.calc_base('scanf', 0x7fffa3b8b040)      # Test this func
         assert lib.address == 0x7fffa3b10000		# Make sure address was set
         assert lib.symbols['str_bin_sh'] == lib.address + orig_binsh	# ELF inherited property
+        context.clear() # Ensure that libc does not affect future tests
  
     def test_C_printf_buffer_bruteforce(self):
         '''A simple example of fsb.find_offset.

--- a/test_automated.py
+++ b/test_automated.py
@@ -8,6 +8,7 @@ showing off common use-cases and best practices.
 import unittest as ut
 # Unfortunately, pytest interprets every `test.*` function as a testable function, so no import * here
 from pwnscripts import system, context, log, fsb, extract_first_hex, fmtstr_payload, is_wsl, extract_all_hex, pack, path, CalledProcessError, libc
+import os, glob
 
 class BinTests(ut.TestCase):
     def test_A_common_sense(self):
@@ -117,5 +118,16 @@ class BinTests(ut.TestCase):
         finally:
             system('rm 3.out')
     # TODO: tests for ROP
+    def test_E_libc(self):
+        '''Simple test to check that local-* libcs will crash for self.dir()
+        '''
+        print()
+        context.libc_database = 'libc-database'
+        context.libc_database.add('examples/libc.so.6')
+        context.libc = 'local-18292bd12d37bfaf58e8dded9db7f1f5da1192cb'
+        self.assertRaises(ValueError, context.libc.dir)
+
+        for f in glob.glob(context.libc.libpath+'*'):   # not that smart
+            os.remove(f)
 if __name__ == '__main__':
     ut.main()

--- a/user_tests_and_examples.py
+++ b/user_tests_and_examples.py
@@ -69,6 +69,9 @@ class BinTests(ut.TestCase):
     # TODO: tests for ROP
     def test_C(self):
         ''' Run a process() with a specific libc version using libc.run_with()
+
+        This test demonstrates how `context.binary.process()` will change behaviour
+        to match `context.libc` (if it is set)
         '''
         print()
         try:

--- a/user_tests_and_examples.py
+++ b/user_tests_and_examples.py
@@ -82,13 +82,13 @@ class BinTests(ut.TestCase):
 
             # This version should cause a double free Abort
             context.libc = 'libc6_2.31-0ubuntu9_amd64'
-            r = context.libc.run_with(context.binary)
+            r = context.binary.process()    # Auto run-with-libc
             r.recvall()
             self.assertEqual(r.poll(), -6)
 
             # This version should permit double frees
             context.libc = 'libc6_2.24-11+deb9u4_amd64'
-            r = context.libc.run_with(context.binary)
+            r = context.binary.process()    # Auto run-with-libc
             r.recvall()
             self.assertEqual(r.poll(), 0)
 

--- a/user_tests_and_examples.py
+++ b/user_tests_and_examples.py
@@ -67,5 +67,32 @@ class BinTests(ut.TestCase):
         finally:
             system('rm 2.out')
     # TODO: tests for ROP
+    def test_C(self):
+        ''' Run a process() with a specific libc version using libc.run_with()
+        '''
+        print()
+        try:
+            system('./examples/fastbin_dup.c')
+            context.binary = 'f.out'
+            path_to_libcdb = 'libc-database'
+            if not path.isdir(path_to_libcdb):
+                path_to_libcdb = input("path to libc-database: ").strip()
+            assert path.isdir(path_to_libcdb)
+            context.libc_database = path_to_libcdb
+
+            # This version should cause a double free Abort
+            context.libc = 'libc6_2.31-0ubuntu9_amd64'
+            r = context.libc.run_with(context.binary)
+            r.recvall()
+            self.assertEqual(r.poll(), -6)
+
+            # This version should permit double frees
+            context.libc = 'libc6_2.24-11+deb9u4_amd64'
+            r = context.libc.run_with(context.binary)
+            r.recvall()
+            self.assertEqual(r.poll(), 0)
+
+        finally:
+            system('rm f.out')
 if __name__ == '__main__':
     ut.main()


### PR DESCRIPTION
This version adds a draft `.run_with()` method to `libc`.
Todo:
* Ideally, `context.binary.process()` should be sensitive to `context.libc` itself, but this is hard to implement without writing changes to pwntools itself. [done]
* replace `env` usage with `.run_with()` [not changing because of nature of test]
* maybe more tests 